### PR TITLE
fix(deploy): drop invalid --production=false from bun install

### DIFF
--- a/elysia-server/Dockerfile
+++ b/elysia-server/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 # Copy lockfile + manifest first to maximize Docker layer cache hits.
 COPY package.json bun.lock ./
 
-RUN bun install --frozen-lockfile --production=false
+RUN bun install --frozen-lockfile
 
 # -----------------------------------------------------------------------------
 # Stage 2: Runtime


### PR DESCRIPTION
## Summary

Bun rejects `--production=false` — it's a boolean flag that doesn't accept a value. The Dokploy build failed at `[deps 4/4] RUN bun install --frozen-lockfile --production=false` with:

\`\`\`
error: The argument '--production' does not take a value.
error: An internal error occurred (DoesntTakeValue)
\`\`\`

Fix: drop the flag entirely. Dev dependencies are installed by default when `--production` is omitted, which is what we want at the `deps` stage (drizzle-kit, biome, types).

## Test plan

- [ ] Dokploy rebuild of elysia-server completes through `bun install`
- [ ] Resulting image still has `node_modules` with dev deps (drizzle-kit available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dropped the invalid `--production=false` flag from `bun install` in `elysia-server/Dockerfile` to fix Dokploy build failures. Omitting the flag installs dev deps by default, which is what we want in the deps stage.

<sup>Written for commit e4e4c50942eab53f463744fd6175fc5e9cba6310. Summary will update on new commits. <a href="https://cubic.dev/pr/FINGU-GRINDA/rinda-ai-crm/pull/38?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

