### PR TITLE
fix(deploy): bump bun base image to 1.3-alpine

### DIFF
--- a/elysia-server/Dockerfile
+++ b/elysia-server/Dockerfile
@@ -10,7 +10,7 @@
 # -----------------------------------------------------------------------------
 # Stage 1: Install dependencies
 # -----------------------------------------------------------------------------
-FROM oven/bun:1.1-alpine AS deps
+FROM oven/bun:1.3-alpine AS deps
 
 WORKDIR /app
 
@@ -22,7 +22,7 @@ RUN bun install --frozen-lockfile
 # -----------------------------------------------------------------------------
 # Stage 2: Runtime
 # -----------------------------------------------------------------------------
-FROM oven/bun:1.1-alpine AS runtime
+FROM oven/bun:1.3-alpine AS runtime
 
 # tini -> proper PID 1 signal handling
 # curl -> used by HEALTHCHECK


### PR DESCRIPTION
## Summary

The previous \`oven/bun:1.1-alpine\` ships Bun 1.1.45, which can't read \`bun.lock\` (now on \`lockfileVersion: 1\`, the text format introduced in Bun 1.2). Dokploy build failed with:

\`\`\`
error: Unknown lockfile version at bun.lock:2:22
InvalidLockfileVersion: failed to parse lockfile: 'bun.lock'
error: lockfile had changes, but lockfile is frozen
\`\`\`

Bumped to \`oven/bun:1.3-alpine\` to match the local Bun (1.3.12) that wrote the lockfile.

## Test plan

- [ ] Dokploy rebuild reaches the \`bun install --frozen-lockfile\` step and completes.
- [ ] Server boots, runs migrations, serves \`/health\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Docker base image from `oven/bun:1.1-alpine` to `oven/bun:1.3-alpine` in both stages to match local Bun and support `lockfileVersion: 1`. This fixes Dokploy builds failing at `bun install --frozen-lockfile` with “Unknown lockfile version” errors.

<sup>Written for commit bd62dd154b36ce9410b44aabb5fc05fa7381ff6b. Summary will update on new commits. <a href="https://cubic.dev/pr/FINGU-GRINDA/rinda-ai-crm/pull/39?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

