### PR TITLE
fix(deploy): lazy-init GoogleOAuthService for optional Google env

### DIFF
--- a/elysia-server/src/services/google-oauth.service.ts
+++ b/elysia-server/src/services/google-oauth.service.ts
@@ -33,8 +33,14 @@ class GoogleOAuthService {
     this.clientId = config.GOOGLE_CLIENT_ID || ""
     this.clientSecret = config.GOOGLE_CLIENT_SECRET || ""
     this.redirectUri = config.GOOGLE_REDIRECT_URI || ""
+  }
 
-    if (!this.clientId || !this.clientSecret || !this.redirectUri) {
+  isConfigured(): boolean {
+    return Boolean(this.clientId && this.clientSecret && this.redirectUri)
+  }
+
+  private assertConfigured(): void {
+    if (!this.isConfigured()) {
       throw new Error(
         "Google OAuth environment variables (GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI) are required",
       )
@@ -42,6 +48,7 @@ class GoogleOAuthService {
   }
 
   getAuthorizationUrl(state: string, flowType: "signin" | "gmail" | "calendar"): string {
+    this.assertConfigured()
     const scopes = this.getScopesForFlowType(flowType)
 
     const params = new URLSearchParams({
@@ -75,6 +82,7 @@ class GoogleOAuthService {
   }
 
   async exchangeCodeForTokens(code: string): Promise<GoogleTokenResponse> {
+    this.assertConfigured()
     const params = new URLSearchParams({
       code,
       client_id: this.clientId,
@@ -100,6 +108,7 @@ class GoogleOAuthService {
   }
 
   async refreshAccessToken(refreshToken: string): Promise<GoogleTokenResponse> {
+    this.assertConfigured()
     const params = new URLSearchParams({
       refresh_token: refreshToken,
       client_id: this.clientId,


### PR DESCRIPTION
## Summary

Server was crashing on boot in production:

\`\`\`
error: Google OAuth environment variables (GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI) are required
  at new GoogleOAuthService (/app/src/services/google-oauth.service.ts:38:17)
  at /app/src/services/google-oauth.service.ts:144:35
\`\`\`

The service is exported as a module-level singleton (\`export const googleOAuthService = new GoogleOAuthService()\`), so a constructor throw kills the whole process — even though \`GOOGLE_CLIENT_ID\` / \`GOOGLE_CLIENT_SECRET\` / \`GOOGLE_REDIRECT_URI\` are marked \`[OPTIONAL]\` in \`.env.example\`.

## Fix

- Drop the throw from the constructor.
- Add \`assertConfigured()\` and call it from each method that actually needs the credentials: \`getAuthorizationUrl\`, \`exchangeCodeForTokens\`, \`refreshAccessToken\`.
- \`getUserInfo\` and \`validateToken\` accept an access token directly, so they don't need the client config — left unguarded.
- Expose \`isConfigured()\` so route handlers can return a proper 4xx instead of throwing.

## Test plan

- [ ] Deploy with Google env vars unset — server should boot and serve \`/health\`.
- [ ] Deploy with Google env vars set — \`/api/auth/google/...\` flows still work.
- [ ] Hit a Google OAuth endpoint with env vars unset — request fails cleanly via the error middleware (does not crash the server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop server crashes on boot when Google OAuth env vars are unset. The Google OAuth service now checks config only when needed, not in the constructor.

- **Bug Fixes**
  - Removed constructor throw in the `GoogleOAuthService` singleton when `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, or `GOOGLE_REDIRECT_URI` are missing.
  - Added `assertConfigured()` and guard `getAuthorizationUrl`, `exchangeCodeForTokens`, and `refreshAccessToken`.
  - Left `getUserInfo` and `validateToken` unguarded (they only need a token) and exposed `isConfigured()` so routes can return a 4xx instead of crashing.

<sup>Written for commit 8b72296d9ae340b8ffeee0257f757404cf9feb03. Summary will update on new commits. <a href="https://cubic.dev/pr/FINGU-GRINDA/rinda-ai-crm/pull/40?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

