### PR TITLE
fix(deploy): relative /api in frontend + JSON/CSV CORS allowlist

### DIFF
--- a/elysia-server/.env.example
+++ b/elysia-server/.env.example
@@ -23,8 +23,10 @@ PORT=3001                         # [OPTIONAL] default: 3001
 NODE_ENV=production               # [OPTIONAL] default: development
 LOGGING_LEVEL=info                # [OPTIONAL] default: info (prod) / debug (dev)
 
-# Comma-separated list of allowed frontend origins (CORS).
-# The first URL is used for OAuth redirects.
+# CORS allowlist. Accepts either format:
+#   - JSON array:      ["https://a.com","https://b.com"]
+#   - Comma-separated: https://a.com,https://b.com
+# The first entry is also used for OAuth redirect origin.
 FRONTEND_URLS=http://localhost:3000,https://app.example.com   # [REQUIRED]
 
 # -----------------------------------------------------------------------------

--- a/elysia-server/src/config.ts
+++ b/elysia-server/src/config.ts
@@ -4,6 +4,21 @@ function getEnvOrDefault(key: string, defaultValue: string): string {
   return process.env[key] || defaultValue
 }
 
+function parseOriginList(raw: string): string[] {
+  const trimmed = raw.trim()
+  if (trimmed.startsWith("[")) {
+    const parsed: unknown = JSON.parse(trimmed)
+    if (!Array.isArray(parsed) || !parsed.every((v): v is string => typeof v === "string")) {
+      throw new Error("FRONTEND_URLS JSON value must be an array of strings")
+    }
+    return parsed.map((url) => url.trim()).filter(Boolean)
+  }
+  return trimmed
+    .split(",")
+    .map((url) => url.trim())
+    .filter(Boolean)
+}
+
 export const NODE_ENV = getEnvOrDefault("NODE_ENV", "development") as
   | "development"
   | "production"
@@ -20,11 +35,14 @@ const configSchema = z.object({
 
   // Server
   PORT: z.coerce.number().default(3001),
-  // Comma-separated list of frontend URLs (for CORS)
+  // CORS allowlist. Accepts either format:
+  //   - JSON array: ["https://a.com","https://b.com"]
+  //   - Comma-separated: https://a.com,https://b.com
+  // First entry is also used as the OAuth redirect origin.
   FRONTEND_URLS: z
     .string()
     .default("http://localhost:3000")
-    .transform((val) => val.split(",").map((url) => url.trim())),
+    .transform((val) => parseOriginList(val)),
 
   // Gemini AI
   GEMINI_API_KEY: z.string().optional(),

--- a/frontend/components/settings/tabs/AISettingsTab.tsx
+++ b/frontend/components/settings/tabs/AISettingsTab.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { IconEye, IconEyeOff, IconCheck, IconLoader, IconExternalLink, IconX } from '../../Icons';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+const API_BASE_URL = import.meta.env.VITE_API_URL ?? '';
 
 export interface AIFormState {
   isDirty: boolean;

--- a/frontend/services/calendarIntegrationService.ts
+++ b/frontend/services/calendarIntegrationService.ts
@@ -2,7 +2,7 @@ import { CalendarEvent, CalendarIntegration, MeetingPreparation, Customer } from
 import { apiClient } from '../src/services/apiClient';
 
 // API base URL
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+const API_BASE_URL = import.meta.env.VITE_API_URL ?? '';
 
 // Calendar Integration Storage (localStorage as fallback)
 const CALENDAR_INTEGRATION_KEY = 'rinda_calendar_integration';

--- a/frontend/services/emailIntegrationService.ts
+++ b/frontend/services/emailIntegrationService.ts
@@ -2,7 +2,7 @@ import { EmailMessage, EmailIntegration, Customer } from '../types';
 import { apiClient } from '../src/services/apiClient';
 
 // API base URL
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+const API_BASE_URL = import.meta.env.VITE_API_URL ?? '';
 
 /**
  * Gmail 연동 상태 가져오기

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -13,9 +13,11 @@ import type {
   ApiMeetingSummary,
 } from '../../../elysia-server/src/types/api'
 
-// Use relative URL to leverage Vite's proxy (avoids CORS issues)
-// The proxy in vite.config.ts will forward /api/* requests to the backend
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+// Empty string => relative /api paths.
+//   dev:  Vite's /api proxy forwards to the API server (vite.config.ts).
+//   prod: nginx in the same container proxies to BACKEND_URL.
+// Set VITE_API_URL at build time only if the bundle should hit the API directly.
+const API_BASE_URL = import.meta.env.VITE_API_URL ?? '';
 
 // Health check response type
 export interface HealthCheckResponse {


### PR DESCRIPTION
## Summary

### Frontend — falls back to relative \`/api\` instead of \`localhost:3001\`

Four files were doing \`import.meta.env.VITE_API_URL || 'http://localhost:3001'\`, so when \`VITE_API_URL\` isn't passed as a Docker **build arg** the production bundle silently hits \`localhost:3001\`. Symptom in prod:

\`\`\`
POST http://localhost:3001/api/auth/register   (from a deployed page)
\`\`\`

Changed the fallback to \`''\`. Now:
- **Dev**: \`fetch('/api/...')\` is served by the Vite dev server, which proxies to the API (\`vite.config.ts\` already does this).
- **Prod**: \`fetch('/api/...')\` hits the frontend container's nginx, which forwards to \`BACKEND_URL\` via the envsubst template.

This is what \`nginx.conf.template\` was already built for — no CORS round-trip needed for the default deployment path.

### Backend — CORS allowlist accepts JSON array or CSV

\`FRONTEND_URLS\` already feeds Elysia's CORS middleware as a comma-separated list. Extended parsing to also accept a JSON array string, so you can paste either format into Dokploy:

\`\`\`
FRONTEND_URLS=["https://rinda-ai-crm.192.3.128.209.sslip.io"]
FRONTEND_URLS=https://rinda-ai-crm.192.3.128.209.sslip.io,https://another.com
\`\`\`

Both documented in \`.env.example\`.

## Deployment notes

Recommended Dokploy setup:
- **frontend** runtime env → \`BACKEND_URL=https://rinda-ai-crm-api.192.3.128.209.sslip.io\`. Leave \`VITE_API_URL\` unset.
- **elysia-server** env → \`FRONTEND_URLS=https://rinda-ai-crm.192.3.128.209.sslip.io\` (or JSON-array form if you have several).

## Test plan

- [ ] Rebuild frontend image without \`VITE_API_URL\` build arg → \`fetch\` calls hit \`/api/...\` (relative)
- [ ] Confirm nginx proxies them to \`BACKEND_URL\`
- [ ] Backend boots with \`FRONTEND_URLS\` set as a JSON array and serves CORS preflight correctly
- [ ] Backend boots with \`FRONTEND_URLS\` set as CSV (existing behavior) and still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken production API calls by defaulting the frontend to relative `/api` when `VITE_API_URL` is unset, and adds flexible CORS config by allowing `FRONTEND_URLS` as JSON array or CSV.

- **Bug Fixes**
  - Frontend no longer falls back to `http://localhost:3001`. Uses relative `/api` instead, so dev goes through Vite proxy and prod through nginx to `BACKEND_URL`.

- **New Features**
  - `FRONTEND_URLS` accepts JSON array or comma-separated list for CORS. First entry is used for OAuth redirect origin. `.env.example` updated.

<sup>Written for commit 2cf0b3c83f6fc6f40a53485b78552dbd2ec52d19. Summary will update on new commits. <a href="https://cubic.dev/pr/FINGU-GRINDA/rinda-ai-crm/pull/41?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

