### PR TITLE
chore(biome): promote 2 zero-violation backend rules warn→error

### DIFF
--- a/elysia-server/biome.json
+++ b/elysia-server/biome.json
@@ -34,12 +34,12 @@
         "noUselessConstructor": "off"
       },
       "style": {
-        "noNonNullAssertion": "warn",
+        "noNonNullAssertion": "error",
         "useConst": "error",
         "useTemplate": "error"
       },
       "suspicious": {
-        "noExplicitAny": "warn",
+        "noExplicitAny": "error",
         "noArrayIndexKey": "off"
       },
       "correctness": {


### PR DESCRIPTION
## Summary

Promotes two Biome rules in `elysia-server/biome.json` from `"warn"` to `"error"`:

- `linter.rules.style.noNonNullAssertion`
- `linter.rules.suspicious.noExplicitAny`

Backend currently has **zero active violations** of either rule, so this is a pure CI tightening — no source changes are required. CI's `bun lint:check` step (which the repo already runs) will now fail if a regression is introduced.

The single existing `// biome-ignore lint/suspicious/noExplicitAny` directive in `elysia-server/src/routes/auth.routes.ts` continues to suppress that one site correctly under `"error"` severity (biome-ignore comments work identically for warn and error).

This is part of the incremental rollout where each unit promotes one or more zero-violation rules in lockstep with CI.

## Test plan

- [x] `cd elysia-server && bun lint:check` exits 0
- [x] `cd elysia-server && bun type-check` exits 0
- [ ] CI lint/build job is green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promote two Biome rules in `elysia-server/biome.json` from "warn" to "error": `style.noNonNullAssertion` and `suspicious.noExplicitAny`.
This tightens CI (`bun lint:check` will fail on regressions) with zero current violations; the existing `// biome-ignore lint/suspicious/noExplicitAny` remains effective.

<sup>Written for commit 97cbead5a9e8f2d315ea92ac1b650673a24c93a6. Summary will update on new commits. <a href="https://cubic.dev/pr/FINGU-GRINDA/rinda-ai-crm/pull/49?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

