### PR TITLE
chore(biome): promote frontend noUnusedFunctionParameters warn→error

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -47,7 +47,7 @@
       "correctness": {
         "noUnusedVariables": "warn",
         "noUnusedImports": "warn",
-        "noUnusedFunctionParameters": "warn",
+        "noUnusedFunctionParameters": "error",
         "useExhaustiveDependencies": "warn",
         "noInvalidUseBeforeDeclaration": "warn",
         "useHookAtTopLevel": "warn"

--- a/frontend/components/CustomerDetailPanel.tsx
+++ b/frontend/components/CustomerDetailPanel.tsx
@@ -639,7 +639,7 @@ const MeetingTabContent: React.FC<{
   loading: boolean
   onMeetingClick: (meeting: MeetingSummary) => void
   onRefresh: () => void
-}> = ({ customer, meetings, loading, onMeetingClick, onRefresh }) => {
+}> = ({ customer: _customer, meetings, loading, onMeetingClick, onRefresh }) => {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">

--- a/frontend/components/TableView.tsx
+++ b/frontend/components/TableView.tsx
@@ -14,7 +14,7 @@ interface TableViewProps {
 
 export const TableView: React.FC<TableViewProps> = ({
   customers,
-  selectedCustomerId,
+  selectedCustomerId: _selectedCustomerId,
   onSelectCustomer,
   selectedRows,
   onSelectionChange,

--- a/frontend/components/settings/tabs/NotificationSettingsTab.tsx
+++ b/frontend/components/settings/tabs/NotificationSettingsTab.tsx
@@ -52,7 +52,7 @@ interface NotificationSettingsTabProps {
 }
 
 export const NotificationSettingsTab: React.FC<NotificationSettingsTabProps> = ({
-  onSettingsChange,
+  onSettingsChange: _onSettingsChange,
 }) => {
   const [settings, setSettings] = useState<NotificationSettings>(() => getNotificationSettings())
 


### PR DESCRIPTION
## Summary
- Flips `correctness/noUnusedFunctionParameters` from `"warn"` to `"error"` in `frontend/biome.json` so CI's `lint:check` fails on new regressions (the existing CI already runs `lint:check`; no workflow edits needed).
- Fixes the 3 pre-existing unused-parameter sites by prefixing each parameter with `_` (Biome's accepted convention for intentionally-unused params), preserving the prop API for callers while satisfying the rule.

### Sites cleaned up
- `frontend/components/TableView.tsx` — `selectedCustomerId` (kept on prop interface for future selection highlighting)
- `frontend/components/CustomerDetailPanel.tsx` — `customer` in `MeetingTabContent` (passed by parent; subcomponent currently does not consume it)
- `frontend/components/settings/tabs/NotificationSettingsTab.tsx` — optional `onSettingsChange` callback

## Test plan
- [x] `cd frontend && npm run lint:check` exits 0 (Found 181 warnings, 0 errors)
- [x] `npm run build` succeeds
- [ ] CI green on this branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promoted Biome rule `correctness/noUnusedFunctionParameters` from warn to error in the frontend so `lint:check` fails on unused params in CI.
Prefixed three intentionally unused props with `_` to keep the public API: `TableView.tsx` selectedCustomerId, `CustomerDetailPanel.tsx` MeetingTabContent customer, and `NotificationSettingsTab.tsx` onSettingsChange.

<sup>Written for commit baa797e9f17df6fb40bff7f0637d4a596f28bb97. Summary will update on new commits. <a href="https://cubic.dev/pr/FINGU-GRINDA/rinda-ai-crm/pull/50?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

