### PR TITLE
chore(biome): promote frontend useIterableCallbackReturn warn→error

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -42,7 +42,7 @@
       "suspicious": {
         "noExplicitAny": "warn",
         "noArrayIndexKey": "off",
-        "useIterableCallbackReturn": "warn"
+        "useIterableCallbackReturn": "error"
       },
       "correctness": {
         "noUnusedVariables": "warn",

--- a/frontend/components/AutoFollowUpScheduler.tsx
+++ b/frontend/components/AutoFollowUpScheduler.tsx
@@ -82,7 +82,9 @@ export const AutoFollowUpScheduler: React.FC<AutoFollowUpSchedulerProps> = ({
       loadFollowUps()
 
       if (onFollowUpScheduled) {
-        newFollowUps.forEach((f) => onFollowUpScheduled(f))
+        newFollowUps.forEach((f) => {
+          onFollowUpScheduled(f)
+        })
       }
     } catch (error) {
       console.error("Auto-scheduling failed:", error)

--- a/frontend/components/BackgroundTaskToast.tsx
+++ b/frontend/components/BackgroundTaskToast.tsx
@@ -26,7 +26,9 @@ export const BackgroundTaskToast: React.FC<BackgroundTaskToastProps> = ({ onView
 
     // Cleanup all timers when effect unmounts or dependencies change
     return () => {
-      timers.forEach((timer) => clearTimeout(timer))
+      timers.forEach((timer) => {
+        clearTimeout(timer)
+      })
     }
   }, [tasks])
 

--- a/frontend/components/BusinessCardScanner.tsx
+++ b/frontend/components/BusinessCardScanner.tsx
@@ -47,7 +47,9 @@ export const BusinessCardScanner: React.FC<BusinessCardScannerProps> = ({
 
   const stopCamera = useCallback(() => {
     if (streamRef.current) {
-      streamRef.current.getTracks().forEach((track) => track.stop())
+      streamRef.current.getTracks().forEach((track) => {
+        track.stop()
+      })
       streamRef.current = null
     }
   }, [])

--- a/frontend/components/MeetingRecorder.tsx
+++ b/frontend/components/MeetingRecorder.tsx
@@ -99,7 +99,9 @@ export const MeetingRecorder: React.FC<MeetingRecorderProps> = ({
         setAudioBlob(blob)
         setAudioUrl(URL.createObjectURL(blob))
         setRecordingStatus("complete")
-        stream.getTracks().forEach((track) => track.stop())
+        stream.getTracks().forEach((track) => {
+          track.stop()
+        })
       }
 
       mediaRecorder.start(1000)

--- a/frontend/components/ProspectDiscovery.tsx
+++ b/frontend/components/ProspectDiscovery.tsx
@@ -964,7 +964,9 @@ export const ProspectDiscovery: React.FC<ProspectDiscoveryProps> = ({
                 input={keywordInput}
                 onChangeInput={setKeywordInput}
                 onAdd={(v) => {
-                  v.split(",").forEach((token) => addToList("keywords", token))
+                  v.split(",").forEach((token) => {
+                    addToList("keywords", token)
+                  })
                   setKeywordInput("")
                 }}
                 onRemove={(v) => removeFromList("keywords", v)}

--- a/frontend/services/contextualSuggestionService.ts
+++ b/frontend/services/contextualSuggestionService.ts
@@ -199,7 +199,9 @@ export const generateAllSuggestions = async (
       allSuggestions.push(...suggestions)
 
       // Save each suggestion
-      suggestions.forEach((s) => saveSuggestion(s))
+      suggestions.forEach((s) => {
+        saveSuggestion(s)
+      })
     } catch (error) {
       console.error(`Failed to generate suggestions for ${customer.name}:`, error)
     }

--- a/frontend/services/notificationService.ts
+++ b/frontend/services/notificationService.ts
@@ -57,7 +57,9 @@ export const markNotificationAsRead = (notificationId: string): void => {
 // Mark all notifications as read
 export const markAllAsRead = (): void => {
   const existing = getNotifications()
-  existing.forEach((n) => (n.read = true))
+  existing.forEach((n) => {
+    n.read = true
+  })
   localStorage.setItem(NOTIFICATIONS_KEY, JSON.stringify(existing))
 }
 


### PR DESCRIPTION
## Summary
- Flip `linter.rules.suspicious.useIterableCallbackReturn` from `"warn"` to `"error"` in `frontend/biome.json`.
- CI already runs `lint:check`, so this promotion is the CI tightening — `.github/workflows/ci.yml` is untouched.
- Fix the 7 existing violations: each was a concise-body arrow passed to `.forEach()` that implicitly returned a value. Converted to block-body arrows so nothing is returned.

## Files fixed
- `frontend/components/AutoFollowUpScheduler.tsx:85` — `newFollowUps.forEach((f) => onFollowUpScheduled(f))`
- `frontend/components/BackgroundTaskToast.tsx:29` — `timers.forEach((timer) => clearTimeout(timer))`
- `frontend/components/BusinessCardScanner.tsx:50` — `streamRef.current.getTracks().forEach((track) => track.stop())`
- `frontend/components/MeetingRecorder.tsx:102` — `stream.getTracks().forEach((track) => track.stop())`
- `frontend/components/ProspectDiscovery.tsx:967` — `v.split(",").forEach((token) => addToList("keywords", token))`
- `frontend/services/contextualSuggestionService.ts:202` — `suggestions.forEach((s) => saveSuggestion(s))`
- `frontend/services/notificationService.ts:60` — `existing.forEach((n) => (n.read = true))`

## Test plan
- [x] `cd frontend && npm run lint:check` exits 0
- [x] `cd frontend && npx tsc --noEmit` — no new errors (40 pre-existing, unchanged)
- [x] `cd frontend && npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promoted Biome rule `suspicious.useIterableCallbackReturn` to error in the frontend and fixed existing violations so CI blocks on implicit returns from iterable callbacks. Converted concise arrow callbacks used with `.forEach()` to block bodies to avoid returning values.

- **Refactors**
  - Updated `frontend/biome.json`: set `useIterableCallbackReturn` to `error`; `lint:check` will now fail on violations.
  - Fixed 7 `.forEach()` callbacks across components/services by switching to block bodies; no workflow changes.

<sup>Written for commit e51920f2833612f66cc6baa995a836e2a5e08a51. Summary will update on new commits. <a href="https://cubic.dev/pr/FINGU-GRINDA/rinda-ai-crm/pull/51?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

