### PR TITLE
chore(biome): promote frontend noNonNullAssertion warn→error

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -626,11 +626,13 @@ export const AppDashboard: React.FC = () => {
     }
 
     try {
-      const response = await apiClient.updateCustomerStatus(selectedCustomerId!, newStatus)
+      const response = await apiClient.updateCustomerStatus(selectedCustomer.id, newStatus)
 
       if (isSuccessResponse(response)) {
         const updatedCustomer = transformApiCustomer(response.data)
-        setCustomers((prev) => prev.map((c) => (c.id === selectedCustomerId ? updatedCustomer : c)))
+        setCustomers((prev) =>
+          prev.map((c) => (c.id === selectedCustomer.id ? updatedCustomer : c)),
+        )
       } else if (isErrorResponse(response)) {
         throw new Error(response.error)
       }
@@ -725,11 +727,13 @@ export const AppDashboard: React.FC = () => {
     if (!selectedCustomer) return
 
     try {
-      const response = await apiClient.updateCustomerStatus(selectedCustomerId!, "lost", reason)
+      const response = await apiClient.updateCustomerStatus(selectedCustomer.id, "lost", reason)
 
       if (isSuccessResponse(response)) {
         const updatedCustomer = transformApiCustomer(response.data)
-        setCustomers((prev) => prev.map((c) => (c.id === selectedCustomerId ? updatedCustomer : c)))
+        setCustomers((prev) =>
+          prev.map((c) => (c.id === selectedCustomer.id ? updatedCustomer : c)),
+        )
       } else if (isErrorResponse(response)) {
         throw new Error(response.error)
       }

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -35,7 +35,7 @@
         "noCommaOperator": "warn"
       },
       "style": {
-        "noNonNullAssertion": "warn",
+        "noNonNullAssertion": "error",
         "useConst": "error",
         "useTemplate": "error"
       },

--- a/frontend/components/AutoFollowUpScheduler.tsx
+++ b/frontend/components/AutoFollowUpScheduler.tsx
@@ -412,17 +412,15 @@ export const AutoFollowUpScheduler: React.FC<AutoFollowUpSchedulerProps> = ({
       )}
 
       {/* Completion Modal */}
-      <FollowUpCompletionModal
-        followUp={completingFollowUp!}
-        customer={
-          completingFollowUp
-            ? customers.find((c) => c.id === completingFollowUp.customerId)
-            : undefined
-        }
-        onComplete={handleComplete}
-        onCancel={() => setCompletingFollowUp(null)}
-        isOpen={completingFollowUp !== null}
-      />
+      {completingFollowUp && (
+        <FollowUpCompletionModal
+          followUp={completingFollowUp}
+          customer={customers.find((c) => c.id === completingFollowUp.customerId)}
+          onComplete={handleComplete}
+          onCancel={() => setCompletingFollowUp(null)}
+          isOpen={completingFollowUp !== null}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/components/ICPSettings.tsx
+++ b/frontend/components/ICPSettings.tsx
@@ -96,17 +96,19 @@ export const ICPSettings: React.FC<Props> = ({
   }
 
   const handleSave = () => {
-    if (!formData.name || formData.name.trim() === "") {
+    const { name, industries, keywords } = formData
+
+    if (!name || name.trim() === "") {
       alert("ICP 프로필 이름을 입력해주세요.")
       return
     }
 
-    if (formData.industries?.length === 0) {
+    if (!industries || industries.length === 0) {
       alert("최소 하나의 산업을 선택해주세요.")
       return
     }
 
-    if (formData.keywords?.length === 0) {
+    if (!keywords || keywords.length === 0) {
       alert("최소 하나의 키워드를 입력해주세요.")
       return
     }
@@ -121,9 +123,9 @@ export const ICPSettings: React.FC<Props> = ({
           ? {
               ...p,
               ...formData,
-              name: formData.name!,
-              industries: formData.industries!,
-              keywords: formData.keywords!,
+              name,
+              industries,
+              keywords,
               updatedAt: now,
             }
           : p,
@@ -132,9 +134,9 @@ export const ICPSettings: React.FC<Props> = ({
       // 새로 생성
       const newProfile: ICPProfile = {
         id: `icp_${now}_${Math.random().toString(36).substr(2, 9)}`,
-        name: formData.name!,
-        industries: formData.industries!,
-        keywords: formData.keywords!,
+        name,
+        industries,
+        keywords,
         companySize: formData.companySize,
         targetRegions: formData.targetRegions,
         createdAt: now,

--- a/frontend/components/followup/CustomerFollowUpWidget.tsx
+++ b/frontend/components/followup/CustomerFollowUpWidget.tsx
@@ -327,13 +327,15 @@ export const CustomerFollowUpWidget: React.FC<CustomerFollowUpWidgetProps> = ({
       />
 
       {/* Completion Modal */}
-      <FollowUpCompletionModal
-        followUp={completingFollowUp!}
-        customer={customer}
-        onComplete={handleComplete}
-        onCancel={() => setCompletingFollowUp(null)}
-        isOpen={completingFollowUp !== null}
-      />
+      {completingFollowUp && (
+        <FollowUpCompletionModal
+          followUp={completingFollowUp}
+          customer={customer}
+          onComplete={handleComplete}
+          onCancel={() => setCompletingFollowUp(null)}
+          isOpen={completingFollowUp !== null}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/components/settings/tabs/ProspectSettingsTab.tsx
+++ b/frontend/components/settings/tabs/ProspectSettingsTab.tsx
@@ -102,17 +102,19 @@ export const ProspectSettingsTab: React.FC<ProspectSettingsTabProps> = ({
   }
 
   const handleSave = () => {
-    if (!formData.name || formData.name.trim() === "") {
+    const { name, industries, keywords } = formData
+
+    if (!name || name.trim() === "") {
       alert("ICP 프로필 이름을 입력해주세요.")
       return
     }
 
-    if (formData.industries?.length === 0) {
+    if (!industries || industries.length === 0) {
       alert("최소 하나의 산업을 선택해주세요.")
       return
     }
 
-    if (formData.keywords?.length === 0) {
+    if (!keywords || keywords.length === 0) {
       alert("최소 하나의 키워드를 입력해주세요.")
       return
     }
@@ -126,9 +128,9 @@ export const ProspectSettingsTab: React.FC<ProspectSettingsTabProps> = ({
           ? {
               ...p,
               ...formData,
-              name: formData.name!,
-              industries: formData.industries!,
-              keywords: formData.keywords!,
+              name,
+              industries,
+              keywords,
               updatedAt: now,
             }
           : p,
@@ -136,9 +138,9 @@ export const ProspectSettingsTab: React.FC<ProspectSettingsTabProps> = ({
     } else {
       const newProfile: ICPProfile = {
         id: `icp_${now}_${Math.random().toString(36).substr(2, 9)}`,
-        name: formData.name!,
-        industries: formData.industries!,
-        keywords: formData.keywords!,
+        name,
+        industries,
+        keywords,
         companySize: formData.companySize,
         targetRegions: formData.targetRegions,
         createdAt: now,

--- a/frontend/services/notificationService.ts
+++ b/frontend/services/notificationService.ts
@@ -422,11 +422,10 @@ export const checkAndSendDailyDigest = async (customers: Customer[]): Promise<vo
         scheduledDate.getFullYear() === today.getFullYear()
       )
     })
-    .map((followUp) => {
+    .flatMap((followUp) => {
       const customer = customers.find((c) => c.id === followUp.customerId)
-      return { customer: customer!, followUp }
+      return customer ? [{ customer, followUp }] : []
     })
-    .filter((item) => item.customer)
 
   const pendingCount = getUpcomingFollowUps(7).length
 


### PR DESCRIPTION
## Summary

- Promote Biome's `style/noNonNullAssertion` rule in `frontend/biome.json` from `warn` to `error`.
- CI tightens automatically — `npm run lint:check` already fails the workflow on lint errors, so flipping the severity is the CI hook.
- Fixed **14 existing violations** across 5 files by replacing `!` with real null/empty guards instead of silencing the type system.

## Files touched

| File | Fix |
| --- | --- |
| `frontend/App.tsx` | Use `selectedCustomer.id` (already narrowed by `if (!selectedCustomer) return`) in two `updateCustomerStatus` calls. |
| `frontend/components/AutoFollowUpScheduler.tsx` | Conditionally render `<FollowUpCompletionModal>` only when `completingFollowUp` is non-null. |
| `frontend/components/followup/CustomerFollowUpWidget.tsx` | Same conditional-render fix. |
| `frontend/components/ICPSettings.tsx` | Destructure `formData` and use real guards on `name` / `industries` / `keywords`. The old `industries?.length === 0` check silently passed when the field was `undefined`. |
| `frontend/components/settings/tabs/ProspectSettingsTab.tsx` | Same destructure + guard fix. |
| `frontend/services/notificationService.ts` | Replace `.map(...).filter(...)` with `.flatMap(...)` so the `customer!` cast is gone. |

## Test plan

- [x] `cd frontend && npm run lint:check` — exits 0 (only warnings remain; 0 errors).
- [x] `cd frontend && npm run build` — Vite build succeeds.
- [x] `cd frontend && npx tsc --noEmit` — no new TS errors introduced (the 40 pre-existing TS errors exist on `main` too).

## Notes

- No workflow file changes — `.github/workflows/ci.yml` already runs `lint:check` and fails the CI on lint errors. Severity flip is the CI tightening.
- The previous `industries?.length === 0` check was a latent bug (returned `false` for `undefined`); the new guard correctly rejects both `undefined` and empty arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promoted Biome’s `style/noNonNullAssertion` to error in the frontend and replaced all `!` assertions with real null checks. This tightens CI (lint errors now fail) and removes 14 violations, fixing a latent validation bug.

- **Refactors**
  - Flip rule to error in `frontend/biome.json`; CI already fails via `npm run lint:check`.
  - Replace `!` with guards:
    - `App.tsx`: use `selectedCustomer.id` after existing guard.
    - `AutoFollowUpScheduler.tsx`, `CustomerFollowUpWidget.tsx`: render completion modal only when `completingFollowUp` exists.
    - `notificationService.ts`: use `.flatMap(...)` to emit only when a customer is found.

- **Bug Fixes**
  - `ICPSettings.tsx`, `ProspectSettingsTab.tsx`: validate missing `industries`/`keywords` as invalid (not just empty arrays).

<sup>Written for commit 33b47fd8822b97eff0054fca93ed73adc1093f62. Summary will update on new commits. <a href="https://cubic.dev/pr/FINGU-GRINDA/rinda-ai-crm/pull/52?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

