### PR TITLE
chore(biome): promote 5 zero-violation frontend rules warn→error

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -32,7 +32,7 @@
       "complexity": {
         "noBannedTypes": "off",
         "noUselessConstructor": "off",
-        "noCommaOperator": "warn"
+        "noCommaOperator": "error"
       },
       "style": {
         "noNonNullAssertion": "error",
@@ -45,15 +45,15 @@
         "useIterableCallbackReturn": "error"
       },
       "correctness": {
-        "noUnusedVariables": "warn",
-        "noUnusedImports": "warn",
+        "noUnusedVariables": "error",
+        "noUnusedImports": "error",
         "noUnusedFunctionParameters": "error",
         "useExhaustiveDependencies": "warn",
         "noInvalidUseBeforeDeclaration": "error",
-        "useHookAtTopLevel": "warn"
+        "useHookAtTopLevel": "error"
       },
       "performance": {
-        "noAccumulatingSpread": "warn"
+        "noAccumulatingSpread": "error"
       },
       "security": {
         "noDangerouslySetInnerHtml": "error"

--- a/frontend/components/ICPSettings.tsx
+++ b/frontend/components/ICPSettings.tsx
@@ -358,7 +358,12 @@ export const ICPSettings: React.FC<Props> = ({
                 type="text"
                 value={industryInput}
                 onChange={(e) => setIndustryInput(e.target.value)}
-                onKeyPress={(e) => e.key === "Enter" && (e.preventDefault(), addIndustry())}
+                onKeyPress={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault()
+                    addIndustry()
+                  }
+                }}
                 className="flex-1 border border-slate-300 rounded-lg p-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none"
                 placeholder="예: SaaS"
               />
@@ -396,7 +401,12 @@ export const ICPSettings: React.FC<Props> = ({
                 type="text"
                 value={keywordInput}
                 onChange={(e) => setKeywordInput(e.target.value)}
-                onKeyPress={(e) => e.key === "Enter" && (e.preventDefault(), addKeyword())}
+                onKeyPress={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault()
+                    addKeyword()
+                  }
+                }}
                 className="flex-1 border border-slate-300 rounded-lg p-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none"
                 placeholder="예: AI, 자동화, 클라우드"
               />

--- a/frontend/components/ProspectDiscovery.tsx
+++ b/frontend/components/ProspectDiscovery.tsx
@@ -71,9 +71,8 @@ const PRESET_REGIONS: RegionPreset[] = [
   { name: "호주", flag: "🇦🇺" },
 ]
 
-const REGION_FLAGS: Record<string, string> = PRESET_REGIONS.reduce(
-  (acc, r) => ({ ...acc, [r.name]: r.flag }),
-  {} as Record<string, string>,
+const REGION_FLAGS: Record<string, string> = Object.fromEntries(
+  PRESET_REGIONS.map((r) => [r.name, r.flag]),
 )
 
 // Heuristic: guess a flag from a free-form region/country string

--- a/frontend/components/settings/tabs/ProspectSettingsTab.tsx
+++ b/frontend/components/settings/tabs/ProspectSettingsTab.tsx
@@ -356,7 +356,12 @@ export const ProspectSettingsTab: React.FC<ProspectSettingsTabProps> = ({
                 type="text"
                 value={industryInput}
                 onChange={(e) => setIndustryInput(e.target.value)}
-                onKeyPress={(e) => e.key === "Enter" && (e.preventDefault(), addIndustry())}
+                onKeyPress={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault()
+                    addIndustry()
+                  }
+                }}
                 className="flex-1 border border-slate-300 rounded-lg p-2 text-sm focus:ring-2 focus:ring-indigo-500 outline-none"
                 placeholder="예: SaaS"
               />
@@ -394,7 +399,12 @@ export const ProspectSettingsTab: React.FC<ProspectSettingsTabProps> = ({
                 type="text"
                 value={keywordInput}
                 onChange={(e) => setKeywordInput(e.target.value)}
-                onKeyPress={(e) => e.key === "Enter" && (e.preventDefault(), addKeyword())}
+                onKeyPress={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault()
+                    addKeyword()
+                  }
+                }}
                 className="flex-1 border border-slate-300 rounded-lg p-2 text-sm focus:ring-2 focus:ring-indigo-500 outline-none"
                 placeholder="예: AI, 자동화, 클라우드"
               />

--- a/frontend/components/ui/Input.tsx
+++ b/frontend/components/ui/Input.tsx
@@ -26,7 +26,8 @@ export const Input: React.FC<InputProps> = ({
   id,
   ...inputProps
 }) => {
-  const inputId = id || React.useId()
+  const generatedId = React.useId()
+  const inputId = id || generatedId
   const hintId = hint || error ? `${inputId}-desc` : undefined
   const hasError = Boolean(error)
 

--- a/frontend/components/ui/Select.tsx
+++ b/frontend/components/ui/Select.tsx
@@ -23,7 +23,8 @@ export const Select: React.FC<SelectProps> = ({
   children,
   ...rest
 }) => {
-  const selectId = id || React.useId()
+  const generatedId = React.useId()
+  const selectId = id || generatedId
   const hintId = hint || error ? `${selectId}-desc` : undefined
   const hasError = Boolean(error)
 

--- a/frontend/components/ui/Textarea.tsx
+++ b/frontend/components/ui/Textarea.tsx
@@ -16,7 +16,8 @@ export const Textarea: React.FC<TextareaProps> = ({
   id,
   ...rest
 }) => {
-  const textareaId = id || React.useId()
+  const generatedId = React.useId()
+  const textareaId = id || generatedId
   const hintId = hint || error ? `${textareaId}-desc` : undefined
   const hasError = Boolean(error)
 


### PR DESCRIPTION
## Summary

Tighten `frontend/biome.json` by flipping five rules from `warn` to `error`. Since CI already runs `lint:check`, flipping the severity *is* the CI tightening — no workflow edits needed.

### Rules promoted (warn → error)

- `linter.rules.complexity.noCommaOperator`
- `linter.rules.correctness.noUnusedVariables`
- `linter.rules.correctness.noUnusedImports`
- `linter.rules.correctness.useHookAtTopLevel`
- `linter.rules.performance.noAccumulatingSpread`

### Violations fixed (baseline had drifted)

The audit assumed these rules were zero-violation, but eight active violations had crept in. Fixed in-place per each rule's intent:

- **`noCommaOperator` (4)** — `components/ICPSettings.tsx`, `components/settings/tabs/ProspectSettingsTab.tsx`: replaced `(e) => e.key === "Enter" && (e.preventDefault(), addX())` comma-operator expressions with explicit block-body `onKeyPress` handlers.
- **`noAccumulatingSpread` (1)** — `components/ProspectDiscovery.tsx`: rewrote `PRESET_REGIONS.reduce((acc, r) => ({ ...acc, [r.name]: r.flag }), {})` as `Object.fromEntries(PRESET_REGIONS.map((r) => [r.name, r.flag]))`.
- **`useHookAtTopLevel` (3)** — `components/ui/Input.tsx`, `components/ui/Select.tsx`, `components/ui/Textarea.tsx`: hoisted `React.useId()` out of `id || React.useId()` short-circuit so the hook is always called unconditionally.

No other rules or fields in `biome.json` were touched (formatter, javascript, json sections unchanged).

## Test plan

- [x] `cd frontend && npm run lint:check` — exits 0 (was: 8 errors)
- [x] `cd frontend && npm run build` — Vite production build succeeds
- [x] `cd frontend && npx tsc --noEmit` — no new TS errors introduced (20 pre-existing baseline errors are out of scope for this unit)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promoted five Biome lint rules from warn to error in the frontend to enforce stricter CI. Fixed eight existing violations so `lint:check` stays green.

- **Refactors**
  - Tightened `frontend/biome.json`: `noCommaOperator`, `noUnusedVariables`, `noUnusedImports`, `useHookAtTopLevel`, `noAccumulatingSpread` → `error`.
  - Fixed 8 violations: replaced comma-operator key handlers in `ICPSettings.tsx` and `ProspectSettingsTab.tsx` (4); rewrote accumulating spread to `Object.fromEntries` in `ProspectDiscovery.tsx` (1); hoisted `React.useId()` in `ui/Input.tsx`, `ui/Select.tsx`, `ui/Textarea.tsx` (3). CI already runs `lint:check`; no workflow changes.

<sup>Written for commit 3868256ece50669936f639ff87f34af2f571f361. Summary will update on new commits. <a href="https://cubic.dev/pr/FINGU-GRINDA/rinda-ai-crm/pull/53?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

