### PR TITLE
ci: add biome format-check step alongside lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Lint (Biome)
         run: bun lint:check
 
+      - name: Format check (Biome)
+        run: bun run format:check
+
       - name: Type-check
         run: bun type-check
 
@@ -57,6 +60,9 @@ jobs:
 
       - name: Lint (Biome)
         run: npm run lint:check
+
+      - name: Format check (Biome)
+        run: npm run format:check
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary

- Adds a dedicated `Format check (Biome)` step to both `backend` and `frontend` CI jobs in `.github/workflows/ci.yml`.
- Step runs `bun run format:check` / `npm run format:check`, which invoke `biome format` (formatter only — no lint rules).

## Rationale

Today, `lint:check` (`biome check`) runs both the linter and the formatter, so a whitespace/quote drift surfaces through the same step as a real rule violation. That makes the failure mode ambiguous and bundles unrelated work together.

A separate `format:check` step makes the failure mode crisper: a red format step signals "run `bun run format` / `npm run format`", while a red lint step signals "a rule was triggered." This is especially useful while the `noExplicitAny` warn→error promotion is rolling through other branches — formatter drift won't masquerade as a lint regression.

No `biome.json` severities or rule configuration were changed. The `format:check` scripts already existed in both `package.json` files; this PR only wires them into CI.

## Test plan

Local gates pass on this branch:

- [x] `cd frontend && npm run lint:check && npm run format:check && npm run build`
- [x] `cd elysia-server && bun lint:check && bun run format:check && bun type-check`

CI will exercise both new steps on this PR.

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dedicated Biome format check step to backend and frontend CI so formatter drift doesn’t get mixed with lint rule failures. The new `Format check (Biome)` runs `bun run format:check` / `npm run format:check`; `lint:check` remains unchanged.

<sup>Written for commit fc7e54ccf6d8d7c6c95bf43e0c46342cd426a0b7. Summary will update on new commits. <a href="https://cubic.dev/pr/FINGU-GRINDA/rinda-ai-crm/pull/54?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

