### PR TITLE
chore(biome): promote frontend useExhaustiveDependencies warn→error

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -48,7 +48,7 @@
         "noUnusedVariables": "error",
         "noUnusedImports": "error",
         "noUnusedFunctionParameters": "error",
-        "useExhaustiveDependencies": "warn",
+        "useExhaustiveDependencies": "error",
         "noInvalidUseBeforeDeclaration": "error",
         "useHookAtTopLevel": "error"
       },

--- a/frontend/components/AIAssistant.tsx
+++ b/frontend/components/AIAssistant.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import {
   clearConversationHistory,
   getConversationHistory,
@@ -21,7 +21,7 @@ export const AIAssistant: React.FC<AIAssistantProps> = ({ customers, onAction })
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const loadConversation = () => {
+  const loadConversation = useCallback(() => {
     const history = getConversationHistory()
     if (history.length === 0) {
       // Add welcome message
@@ -36,11 +36,7 @@ export const AIAssistant: React.FC<AIAssistantProps> = ({ customers, onAction })
     } else {
       setMessages(history)
     }
-  }
-
-  const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
-  }
+  }, [])
 
   useEffect(() => {
     if (isOpen) {
@@ -49,9 +45,12 @@ export const AIAssistant: React.FC<AIAssistantProps> = ({ customers, onAction })
     }
   }, [isOpen, loadConversation])
 
+  // Auto-scroll to the latest message whenever messages change. The effect doesn't
+  // read messages directly (only the ref) but must re-run on each messages update.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: messages is the scroll trigger
   useEffect(() => {
-    scrollToBottom()
-  }, [scrollToBottom])
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+  }, [messages])
 
   const handleSend = async () => {
     if (!input.trim() || isLoading) return

--- a/frontend/components/ApiKeySettings.tsx
+++ b/frontend/components/ApiKeySettings.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import {
   IconCheck,
   IconExternalLink,
@@ -25,9 +25,9 @@ export const ApiKeySettings: React.FC<ApiKeySettingsProps> = ({ isOpen, onClose 
   const [errorMessage, setErrorMessage] = useState("")
   const [currentMaskedKey, setCurrentMaskedKey] = useState<string | null>(null)
 
-  const validateApiKey = async () => {
+  const validateApiKey = useCallback(async () => {
     setErrorMessage("API Key 관리가 서버로 이동되었습니다. 서버 환경설정을 확인해주세요.")
-  }
+  }, [])
 
   useEffect(() => {
     if (isOpen) {

--- a/frontend/components/AutoFollowUpScheduler.tsx
+++ b/frontend/components/AutoFollowUpScheduler.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import {
   autoScheduleFollowUps,
   completeScheduledFollowUp,
@@ -60,12 +60,12 @@ export const AutoFollowUpScheduler: React.FC<AutoFollowUpSchedulerProps> = ({
     return filterFollowUps(pending, filters, customers)
   }, [scheduledFollowUps, filters, customers])
 
-  const loadFollowUps = () => {
+  const loadFollowUps = useCallback(() => {
     const all = getScheduledFollowUps()
     setScheduledFollowUps(all)
     setDueFollowUps(getDueFollowUps())
     setUpcomingFollowUps(getUpcomingFollowUps(7))
-  }
+  }, [])
 
   useEffect(() => {
     loadFollowUps()

--- a/frontend/components/FollowUpPanel.tsx
+++ b/frontend/components/FollowUpPanel.tsx
@@ -115,13 +115,7 @@ export const FollowUpPanel: React.FC<FollowUpPanelProps> = ({
         generateNewStrategy()
       }
     }
-  }, [
-    customer.id,
-    customer.followUpStrategy,
-    loadStoredStrategy, // Fallback: generate on-demand for customers without stored strategy
-    generateNewStrategy,
-    customer,
-  ])
+  }, [customer, loadStoredStrategy, generateNewStrategy])
 
   // Keep generateStrategy for the "regenerate" button
   const generateStrategy = generateNewStrategy

--- a/frontend/components/MeetingPrep.tsx
+++ b/frontend/components/MeetingPrep.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { generateMeetingPreparation } from "../services/calendarIntegrationService"
 import type { CalendarEvent, Customer, MeetingPreparation } from "../types"
 import {
@@ -24,7 +24,7 @@ export const MeetingPrep: React.FC<MeetingPrepProps> = ({ customer, event, onClo
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const loadPreparation = async () => {
+  const loadPreparation = useCallback(async () => {
     setIsLoading(true)
     setError(null)
 
@@ -36,7 +36,7 @@ export const MeetingPrep: React.FC<MeetingPrepProps> = ({ customer, event, onClo
     } finally {
       setIsLoading(false)
     }
-  }
+  }, [customer, event])
 
   useEffect(() => {
     if (event.meetingPrep) {

--- a/frontend/components/MeetingRecorder.tsx
+++ b/frontend/components/MeetingRecorder.tsx
@@ -17,6 +17,15 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { apiClient } from "../src/services/apiClient"
 import type { Customer, MeetingSummary, RecordingStatus } from "../types"
 
+const blobToBase64 = (blob: Blob): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onloadend = () => resolve(reader.result as string)
+    reader.onerror = reject
+    reader.readAsDataURL(blob)
+  })
+}
+
 interface MeetingRecorderProps {
   isOpen: boolean
   onClose: () => void
@@ -180,15 +189,6 @@ export const MeetingRecorder: React.FC<MeetingRecorderProps> = ({
     }
   }, [isPlaying])
 
-  const blobToBase64 = (blob: Blob): Promise<string> => {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onloadend = () => resolve(reader.result as string)
-      reader.onerror = reject
-      reader.readAsDataURL(blob)
-    })
-  }
-
   const generateSummary = useCallback(async () => {
     // Validate required fields
     if (!audioBlob || !selectedCustomerId || !title || !meetingDate) {
@@ -226,7 +226,7 @@ export const MeetingRecorder: React.FC<MeetingRecorderProps> = ({
       setError(err.message || "미팅 요약 생성에 실패했습니다.")
       setRecordingStatus("error")
     }
-  }, [audioBlob, selectedCustomerId, title, meetingDate, onComplete, blobToBase64])
+  }, [audioBlob, selectedCustomerId, title, meetingDate, onComplete])
 
   const handleClose = useCallback(() => {
     if (

--- a/frontend/components/NotificationCenter.tsx
+++ b/frontend/components/NotificationCenter.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import {
   deleteNotification,
   getNotifications,
@@ -33,28 +33,38 @@ export const NotificationCenter: React.FC<NotificationCenterProps> = ({
   const [isOpen, setIsOpen] = useState(false)
   const [isChecking, setIsChecking] = useState(false)
 
-  const loadNotifications = () => {
+  const loadNotifications = useCallback(() => {
     const all = getNotifications()
     setNotifications(all)
     setUnreadCount(getUnreadCount())
-  }
+  }, [])
 
-  const checkNotifications = async () => {
+  // Keep a ref to the latest customers so the interval callback always sees fresh data
+  // without having to re-create the interval each time the customers list changes.
+  const customersRef = useRef(customers)
+  useEffect(() => {
+    customersRef.current = customers
+  }, [customers])
+
+  const checkNotifications = useCallback(async () => {
     setIsChecking(true)
     try {
-      await runNotificationChecks(customers)
+      await runNotificationChecks(customersRef.current)
       loadNotifications()
     } catch (error) {
       console.error("Notification check failed:", error)
     } finally {
       setIsChecking(false)
     }
-  }
+  }, [loadNotifications])
 
-  // Load notifications on mount
+  // Load notifications on mount and reload when customers change.
+  // `customers` is intentionally in the deps so a new customer list re-reads the
+  // local notification store (loadNotifications doesn't reference customers directly).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: customers is the trigger, not a value read
   useEffect(() => {
     loadNotifications()
-  }, [loadNotifications])
+  }, [loadNotifications, customers])
 
   // Check for new notifications every 5 minutes (independent of customers)
   useEffect(() => {
@@ -67,11 +77,6 @@ export const NotificationCenter: React.FC<NotificationCenterProps> = ({
 
     return () => clearInterval(interval)
   }, [checkNotifications])
-
-  // Reload notifications when customers change
-  useEffect(() => {
-    loadNotifications()
-  }, [loadNotifications])
 
   const handleNotificationClick = (notification: Notification) => {
     if (!notification.read) {

--- a/frontend/components/followup/CustomerFollowUpWidget.tsx
+++ b/frontend/components/followup/CustomerFollowUpWidget.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import {
   completeScheduledFollowUp,
   deleteScheduledFollowUp,
@@ -84,10 +84,10 @@ export const CustomerFollowUpWidget: React.FC<CustomerFollowUpWidgetProps> = ({
   const [completingFollowUp, setCompletingFollowUp] = useState<ScheduledFollowUp | null>(null)
 
   // Load follow-ups for this customer
-  const loadFollowUps = () => {
+  const loadFollowUps = useCallback(() => {
     const customerFollowUps = getCustomerFollowUps(customer.id)
     setFollowUps(customerFollowUps)
-  }
+  }, [customer.id])
 
   useEffect(() => {
     loadFollowUps()

--- a/frontend/components/settings/UnifiedSettings.tsx
+++ b/frontend/components/settings/UnifiedSettings.tsx
@@ -89,7 +89,7 @@ export const UnifiedSettings: React.FC<UnifiedSettingsProps> = ({
           : null
 
   // Update connection status on open and when settings change
-  const updateConnectionStatus = () => {
+  const updateConnectionStatus = useCallback(() => {
     const emailSettings = safeGetItem<{ isConnected?: boolean }>("rinda_email_settings", {})
     const calendarSettings = safeGetItem<{ isConnected?: boolean }>("rinda_calendar_settings", {})
     const mixpanelSettings = safeGetItem<{ isEnabled?: boolean }>("rinda_mixpanel_settings", {})
@@ -101,7 +101,7 @@ export const UnifiedSettings: React.FC<UnifiedSettingsProps> = ({
       calendar: calendarSettings.isConnected || false,
       mixpanel: mixpanelSettings.isEnabled || false,
     })
-  }
+  }, [])
 
   useEffect(() => {
     if (isOpen) {

--- a/frontend/components/settings/tabs/AISettingsTab.tsx
+++ b/frontend/components/settings/tabs/AISettingsTab.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { IconCheck, IconExternalLink, IconEye, IconEyeOff, IconLoader, IconX } from "../../Icons"
 
 const API_BASE_URL = import.meta.env.VITE_API_URL ?? ""
@@ -38,7 +38,7 @@ export const AISettingsTab: React.FC<AISettingsTabProps> = ({
   // Track if form has unsaved changes
   const isDirty = apiKey.trim().length > 0
 
-  const fetchServerStatus = async () => {
+  const fetchServerStatus = useCallback(async () => {
     setIsLoadingServerStatus(true)
     try {
       const response = await fetch(`${API_BASE_URL}/api/ai/status`)
@@ -53,28 +53,25 @@ export const AISettingsTab: React.FC<AISettingsTabProps> = ({
     } finally {
       setIsLoadingServerStatus(false)
     }
-  }
+  }, [])
 
-  useEffect(() => {
-    // 서버 AI 상태 확인
-    fetchServerStatus()
-  }, [
-    // 서버 AI 상태 확인
-    fetchServerStatus,
-  ])
-
-  const handleSave = async () => {
+  const handleSave = useCallback(async () => {
     setErrorMessage(
       "API Key 관리가 서버로 이동되었습니다. 서버 환경설정을 통해 GEMINI_API_KEY를 설정하세요.",
     )
     setSuccessMessage("")
-  }
+  }, [])
 
-  const handleReset = () => {
+  const handleReset = useCallback(() => {
     setApiKey("")
     setErrorMessage("")
     setSuccessMessage("")
-  }
+  }, [])
+
+  useEffect(() => {
+    // 서버 AI 상태 확인
+    fetchServerStatus()
+  }, [fetchServerStatus])
 
   // Report form state to parent component
   useEffect(() => {

--- a/frontend/components/settings/tabs/MixpanelIntegrationTab.tsx
+++ b/frontend/components/settings/tabs/MixpanelIntegrationTab.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { IconCheck, IconExternalLink, IconLoader, IconRefresh, IconX } from "../../Icons"
 
 interface MixpanelSettings {
@@ -68,7 +68,7 @@ export const MixpanelIntegrationTab: React.FC<MixpanelIntegrationTabProps> = ({
   const [successMessage, setSuccessMessage] = useState("")
   const [newEvent, setNewEvent] = useState("")
 
-  const fetchSettings = async () => {
+  const fetchSettings = useCallback(async () => {
     try {
       const response = await fetch(`${API_BASE}/mixpanel/settings`)
       if (response.ok) {
@@ -86,9 +86,9 @@ export const MixpanelIntegrationTab: React.FC<MixpanelIntegrationTabProps> = ({
     } finally {
       setIsLoading(false)
     }
-  }
+  }, [])
 
-  const fetchConnectionStatus = async () => {
+  const fetchConnectionStatus = useCallback(async () => {
     try {
       const response = await fetch(`${API_BASE}/mixpanel/connection-status`)
       if (response.ok) {
@@ -98,7 +98,7 @@ export const MixpanelIntegrationTab: React.FC<MixpanelIntegrationTabProps> = ({
     } catch (error) {
       console.error("Failed to fetch connection status:", error)
     }
-  }
+  }, [])
 
   // Load settings on mount
   useEffect(() => {
@@ -113,7 +113,7 @@ export const MixpanelIntegrationTab: React.FC<MixpanelIntegrationTabProps> = ({
   }, [formData, originalData])
 
   // Submit all form changes
-  const handleSubmit = async () => {
+  const handleSubmit = useCallback(async () => {
     setIsSaving(true)
     setErrorMessage("")
     setSuccessMessage("")
@@ -145,14 +145,14 @@ export const MixpanelIntegrationTab: React.FC<MixpanelIntegrationTabProps> = ({
     } finally {
       setIsSaving(false)
     }
-  }
+  }, [formData, onSettingsChange])
 
   // Reset form to original state
-  const handleReset = () => {
+  const handleReset = useCallback(() => {
     setFormData(originalData)
     setErrorMessage("")
     setSuccessMessage("")
-  }
+  }, [originalData])
 
   // Field handlers - only update local state
   const handleToggleEnabled = (enabled: boolean) => {

--- a/frontend/components/settings/tabs/SlackIntegrationTab.tsx
+++ b/frontend/components/settings/tabs/SlackIntegrationTab.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import {
   getSlackSettings,
   saveSlackSettings,
@@ -71,7 +71,7 @@ export const SlackIntegrationTab: React.FC<SlackIntegrationTabProps> = ({
   }, [webhookUrl, formData.webhookUrl])
 
   // Submit all form changes
-  const handleSubmit = async () => {
+  const handleSubmit = useCallback(async () => {
     setIsSaving(true)
     setErrorMessage("")
     setSuccessMessage("")
@@ -86,16 +86,16 @@ export const SlackIntegrationTab: React.FC<SlackIntegrationTabProps> = ({
     } finally {
       setIsSaving(false)
     }
-  }
+  }, [formData, onSettingsChange])
 
   // Reset form to original state
-  const handleReset = () => {
+  const handleReset = useCallback(() => {
     setFormData(originalData)
     setWebhookUrl(originalData.webhookUrl)
     setValidationStatus(originalData.isValidated ? "valid" : "idle")
     setErrorMessage("")
     setSuccessMessage("")
-  }
+  }, [originalData])
 
   // Report form state to parent component
   useEffect(() => {


### PR DESCRIPTION
## Summary

Promote Biome's `correctness/useExhaustiveDependencies` rule from `warn` to `error` in `frontend/biome.json`. CI's `lint:check` now fails when this rule is violated, tightening the gate without touching `.github/workflows/ci.yml`.

The promotion uncovered **21 violations across 13 files** (more than the ~4 the unit description estimated). All of them are the same shape: a function declared with `const fn = () => ...` inside the component, used as a `useEffect`/`useMemo` dependency. Per-render the function identity changes, so the rule complains.

## Files / hooks touched

| File | Hook(s) | Fix |
| --- | --- | --- |
| `components/AIAssistant.tsx` | `loadConversation`, scroll effect | Wrap `loadConversation` in `useCallback([])`. Inline `scrollToBottom` body into the effect; depend on `messages`; suppress with justified `biome-ignore` (messages is the re-run trigger, not read). |
| `components/ApiKeySettings.tsx` | `validateApiKey` | `useCallback([])` — body only calls `setErrorMessage`. |
| `components/AutoFollowUpScheduler.tsx` | `loadFollowUps` | `useCallback([])` — body only uses imported helpers + setters. |
| `components/FollowUpPanel.tsx` | `generateNewStrategy` | `useCallback([customer, isLostDeal])`. Simplified the effect deps from 5 entries to 3. |
| `components/MeetingPrep.tsx` | `loadPreparation` | `useCallback([customer, event])`. |
| `components/MeetingRecorder.tsx` | `blobToBase64` | Hoisted to module scope — it's a pure helper, no need to live inside the component. Removed from `generateSummary`'s deps. |
| `components/NotificationCenter.tsx` | `loadNotifications`, `checkNotifications`, 3 effects | `useCallback` both. Use a `customersRef` so the 5-min interval doesn't restart on every `customers` change. Merged the two duplicate `loadNotifications` effects into one with `[loadNotifications, customers]` and a justified `biome-ignore`. |
| `components/followup/CustomerFollowUpWidget.tsx` | `loadFollowUps` | `useCallback([customer.id])`. |
| `components/settings/UnifiedSettings.tsx` | `updateConnectionStatus` | `useCallback([])` — body only reads from `safeGetItem` and calls setters. |
| `components/settings/tabs/AISettingsTab.tsx` | `fetchServerStatus`, `handleSave`, `handleReset` | All `useCallback([])` — bodies only use setters / module-scope constants. |
| `components/settings/tabs/MixpanelIntegrationTab.tsx` | `fetchSettings`, `fetchConnectionStatus`, `handleSubmit`, `handleReset` | `useCallback`; `handleSubmit` deps on `[formData, onSettingsChange]`, `handleReset` on `[originalData]`. |
| `components/settings/tabs/SlackIntegrationTab.tsx` | `handleSubmit`, `handleReset` | Same pattern as Mixpanel. |
| `frontend/biome.json` | `useExhaustiveDependencies` | `warn` → `error`. |

## Behavioral risk analysis

Per the unit instructions, naively appending deps can cause infinite re-render loops. I walked each modified `useEffect` after the change:

- All new `useCallback` wraps memoize on **stable references** (props, `customer.id`, etc.) — none capture freshly-created objects/arrays each render.
- **AIAssistant**: scroll effect now re-fires on each `messages` update (previously fired on every render via unstable function dep). More efficient, same UX.
- **NotificationCenter**: previously the interval cleared/recreated on **every parent render** (unstable dep). Now created once on mount via stable `useCallback`. The `customersRef` ensures the 5-min sweep always picks up the latest customers without restarting the interval. The merged effect still re-reads notifications when `customers` changes (justified `biome-ignore`).
- **FollowUpPanel**: previously effect re-ran every parent render. Now re-runs only when `customer` or `isLostDeal` actually change — fewer redundant AI calls.
- **MeetingPrep / MeetingRecorder / settings tabs**: bodies use only setters + props that don't mutate during the effect — no loop risk.

Two `biome-ignore` suppressions are used, both with a one-line justification on the same line as required by the rule.

## Test plan

- [x] `npm run lint:check` exit 0 (was 151 warnings only; previously had 21 errors from this rule)
- [x] `npx tsc --noEmit` — 16 pre-existing errors in untouched files (KanbanBoard, AuthContext, etc.); my diff introduces zero new TS errors and actually fixed 24 pre-existing `noInvalidUseBeforeDeclaration` related TS errors by reordering callbacks before effects.
- [x] `npm run build` passes (Vite build, 1961 modules)
- [x] Re-read each modified hook site end-to-end for stale-closure / infinite-loop risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promote Biome’s `correctness/useExhaustiveDependencies` rule in `frontend/biome.json` from warn to error and fix 21 violations across 13 files. `lint:check` will now fail on missing or unstable hook deps; fixes use `useCallback` and a few safe refactors.

- **Refactors**
  - Wrapped in-component functions with `useCallback` so `useEffect`/`useMemo` deps are stable.
  - Hoisted pure helper `blobToBase64` to module scope in `MeetingRecorder`.
  - `NotificationCenter`: added `customersRef`, kept the 5‑min interval stable, and merged duplicate load effects; reloads on `customers` with a justified `biome-ignore`.
  - `AIAssistant`: auto-scroll now depends on `messages` with a justified `biome-ignore`.

- **Migration**
  - New lint gate: `useExhaustiveDependencies` is `error`; ensure hook deps are exhaustive and stable (wrap callbacks with `useCallback` as needed).
  - No behavior changes expected; fewer unnecessary effect reruns.

<sup>Written for commit 8f4c2eb710a40fc12dbb14b5455c1dc3fe1e28ec. Summary will update on new commits. <a href="https://cubic.dev/pr/FINGU-GRINDA/rinda-ai-crm/pull/57?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

