### PR TITLE
fix(types): resolve pre-existing tsc errors (excl. AuthContext)

### DIFF
--- a/frontend/components/KanbanBoard.tsx
+++ b/frontend/components/KanbanBoard.tsx
@@ -33,7 +33,7 @@ const Tooltip: React.FC<{ text: string; children: React.ReactNode }> = ({ text, 
   )
 }
 
-const KANBAN_ORDER: CustomerStatus[] = ["new", "contact", "negotiation", "won", "lost"]
+const KANBAN_ORDER: CustomerStatus[] = ["prospect", "new", "contact", "negotiation", "won", "lost"]
 
 export const KANBAN_COLUMNS: { id: CustomerStatus; title: string; accent: string }[] =
   KANBAN_ORDER.map((id) => ({
@@ -48,6 +48,7 @@ interface KanbanBoardProps {
   onSelectCustomer: (customerId: string) => void
   onDeleteCustomer: (customer: Customer) => void
   onStatusChange: (customerId: string, newStatus: CustomerStatus) => Promise<void>
+  onConvertProspect?: (prospectId: string) => Promise<unknown>
   onAddCustomer?: () => void
 }
 
@@ -57,6 +58,7 @@ export const KanbanBoard: React.FC<KanbanBoardProps> = ({
   onSelectCustomer,
   onDeleteCustomer,
   onStatusChange,
+  onConvertProspect,
   onAddCustomer,
 }) => {
   const [draggedCustomerId, setDraggedCustomerId] = useState<string | null>(null)
@@ -102,6 +104,11 @@ export const KanbanBoard: React.FC<KanbanBoardProps> = ({
   const EmptyState: React.FC<{ columnId: CustomerStatus }> = ({ columnId }) => {
     const messages: Record<CustomerStatus, { title: string; subtitle?: string; showCTA: boolean }> =
       {
+        prospect: {
+          title: "잠재 고객이 없습니다",
+          subtitle: "AI 발굴에서 전환된 잠재 고객이 이 칼럼에 표시됩니다",
+          showCTA: false,
+        },
         new: {
           title: "신규 고객이 없습니다",
           subtitle: "고객을 추가하거나 잠재 고객에서 전환해 보세요",
@@ -221,6 +228,18 @@ export const KanbanBoard: React.FC<KanbanBoardProps> = ({
           </div>
         )}
 
+        {customer.status === "prospect" && onConvertProspect && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              void onConvertProspect(customer.id)
+            }}
+            className="w-full mb-2 px-2 py-1.5 text-xs font-medium text-blue-600 bg-blue-50 hover:bg-blue-100 rounded-md transition-colors"
+          >
+            고객으로 전환
+          </button>
+        )}
+
         <div className="flex items-center justify-between text-xs text-slate-400 pt-2 border-t border-slate-50">
           <span>{formatSafeDate(undefined)}</span>
           <IconArrowRight className="w-3 h-3 opacity-0 group-hover:opacity-100 text-blue-500 transition-opacity" />
@@ -310,7 +329,9 @@ export const KanbanBoard: React.FC<KanbanBoardProps> = ({
             return (
               <div
                 key={column.id}
-                ref={(el) => (columnRefs.current[idx] = el)}
+                ref={(el) => {
+                  columnRefs.current[idx] = el
+                }}
                 role="region"
                 aria-label={`${column.title} 칼럼 - ${columnCustomers.length}개 항목`}
                 className={`w-[85vw] flex-shrink-0 snap-center flex flex-col rounded-xl bg-white border-l-4 ${column.accent} border-r border-t border-b border-neutral-200 overflow-hidden`}

--- a/frontend/components/ui/Select.tsx
+++ b/frontend/components/ui/Select.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+interface SelectProps extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, "size"> {
   label?: string
   hint?: string
   error?: string

--- a/frontend/styles/design-tokens.ts
+++ b/frontend/styles/design-tokens.ts
@@ -97,9 +97,10 @@ export const toneStyles: Record<
 // ============================================================
 // 고객 상태 (CustomerStatus) 통일 매핑
 // ============================================================
-export type CustomerStatusKey = "new" | "contact" | "negotiation" | "won" | "lost"
+export type CustomerStatusKey = "prospect" | "new" | "contact" | "negotiation" | "won" | "lost"
 
 export const statusBadge: Record<CustomerStatusKey, { label: string; tone: Tone }> = {
+  prospect: { label: "잠재", tone: "accent" },
   new: { label: "신규", tone: "neutral" },
   contact: { label: "컨택 중", tone: "info" },
   negotiation: { label: "협상 중", tone: "warning" },


### PR DESCRIPTION
## Summary

Resolves 5 of the 7 pre-existing `tsc --noEmit` errors on `origin/main`. The remaining 2 errors (`contexts/AuthContext.tsx:50,117`) are explicitly out of scope — a parallel `noExplicitAny` worker is rewriting those casts.

## Errors fixed

- **`App.tsx:440`** — Typed `apiClient.request` with explicit `ApiResponse<unknown>` generic and narrowed the unwrapped payload to a local `RawEnrichment` shape. `isSuccessResponse` now works without the previous `(response as any)` casts.
- **`App.tsx:974` + `components/KanbanBoard.tsx:103`** — `KanbanBoard` now accepts `onConvertProspect?: (prospectId: string) => Promise<unknown>`, renders the missing `prospect` column (added to `KANBAN_ORDER`, `statusBadge` in `design-tokens.ts`, and the `EmptyState` message record), and shows a "고객으로 전환" CTA on cards whose status is `"prospect"`.
- **`components/KanbanBoard.tsx:313`** — Converted the ref callback to a block body so it returns `void` (React 19 tightened ref-callback return types — returning the element is now a type error).
- **`components/ui/Select.tsx:3`** — Used `Omit<…, "size">` on the HTMLAttributes base interface (matching `Input.tsx`'s convention) so the custom `size: "sm" | "md" | "lg"` prop no longer clashes with the native `size: number` attribute. No callers pass `size` to `Select` today.

## Out of scope (intentionally not touched)

- `contexts/AuthContext.tsx` lines 50 & 117 — parallel `noExplicitAny` worker.
- 4 other pre-existing `tsc` errors on `origin/main` (`index.tsx` react-dom/client types, `services/autoFollowUpService.ts` x2, `src/utils/apiTransformers.ts`) that were not in the task's fix-target list.

## Test plan

- [x] `cd frontend && npm run lint:check` — exit 0
- [x] `cd frontend && npm run build` — exit 0
- [x] `cd frontend && npx tsc --noEmit` — the 5 target errors are gone (6 unrelated pre-existing errors remain, including the 2 AuthContext entries)
- [ ] Smoke-test the Kanban prospect column in the browser (drag-to-status + click the "고객으로 전환" CTA on a prospect card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 5 of 7 pre-existing TypeScript errors and adds the missing Kanban “prospect” column with a convert action. The two `contexts/AuthContext.tsx` errors remain and will be handled separately.

- **Bug Fixes**
  - Typed `apiClient.request` as `ApiResponse<unknown>` and narrowed the payload to `RawEnrichment`, removing `any` casts while keeping `isSuccessResponse` intact.
  - Kanban: added `prospect` column and `statusBadge`, optional `onConvertProspect`, updated empty-state copy, and show “고객으로 전환” on `prospect` cards.
  - Converted a ref callback to a block body to return `void` for React 19’s stricter ref types.
  - `Select` props now use `Omit<..., "size">` to avoid clashing with the native `size: number` attribute.

<sup>Written for commit 133642344632efaa9d7654fb75f5bfad640de4bf. Summary will update on new commits. <a href="https://cubic.dev/pr/FINGU-GRINDA/rinda-ai-crm/pull/59?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

