### PR TITLE
fix(types): drive frontend tsc to zero and gate it in lefthook + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Format check (Biome)
         run: npm run format:check
 
+      - name: Type-check (tsc)
+        run: npx tsc --noEmit
+
       - name: Build
         run: npm run build
         env:

--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -36,6 +36,28 @@ export function useAuth() {
   return context
 }
 
+function isUser(value: unknown): value is User {
+  if (typeof value !== "object" || value === null) return false
+  const v = value as Record<string, unknown>
+  return (
+    typeof v.id === "string" &&
+    typeof v.email === "string" &&
+    typeof v.name === "string" &&
+    typeof v.emailVerified === "boolean" &&
+    (v.picture === undefined || typeof v.picture === "string")
+  )
+}
+
+function extractUser(data: unknown): User | null {
+  if (isUser(data)) return data
+  // Some endpoints wrap the user under a `user` key
+  if (typeof data === "object" && data !== null && "user" in data) {
+    const wrapped = (data as { user: unknown }).user
+    if (isUser(wrapped)) return wrapped
+  }
+  return null
+}
+
 interface AuthProviderProps {
   children: ReactNode
 }
@@ -48,7 +70,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     try {
       const response = await apiClient.getCurrentUser()
       if (response.success && response.data) {
-        setUser(response.data as unknown as User)
+        setUser(extractUser(response.data))
       } else {
         setUser(null)
       }
@@ -68,7 +90,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     try {
       const response = await apiClient.register({ email, password, name })
       if (response.success && response.data) {
-        setUser(response.data.user as User)
+        const parsed = extractUser(response.data)
+        if (!parsed) {
+          return { success: false, error: "Invalid registration response" }
+        }
+        setUser(parsed)
         return { success: true }
       }
       return { success: false, error: getErrorMessage(response) || "Registration failed" }
@@ -82,7 +108,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     try {
       const response = await apiClient.login({ email, password })
       if (response.success && response.data) {
-        setUser(response.data.user as User)
+        const parsed = extractUser(response.data)
+        if (!parsed) {
+          return { success: false, error: "Invalid login response" }
+        }
+        setUser(parsed)
         return { success: true }
       }
       return { success: false, error: getErrorMessage(response) || "Login failed" }
@@ -116,7 +146,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     try {
       const response = await apiClient.getCurrentUser()
       if (response.success && response.data) {
-        setUser(response.data as unknown as User)
+        const parsed = extractUser(response.data)
+        if (!parsed) {
+          return { success: false }
+        }
+        setUser(parsed)
         return { success: true }
       }
       return { success: false }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,8 @@
         "@biomejs/biome": "^2.4.15",
         "@tailwindcss/postcss": "^4.1.18",
         "@types/node": "^22.14.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.0.0",
         "autoprefixer": "^10.4.23",
         "postcss": "^8.5.6",
@@ -2134,13 +2136,22 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/unist": {
@@ -2381,8 +2392,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,8 @@
     "@biomejs/biome": "^2.4.15",
     "@tailwindcss/postcss": "^4.1.18",
     "@types/node": "^22.14.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.23",
     "postcss": "^8.5.6",

--- a/frontend/services/autoFollowUpService.ts
+++ b/frontend/services/autoFollowUpService.ts
@@ -423,13 +423,11 @@ export const filterFollowUps = (
   }
 
   // Filter by date range
-  if (filters.dateRange) {
+  const { dateRange } = filters
+  if (dateRange) {
     result = result.filter((f) => {
       const scheduledForTimestamp = new Date(f.scheduledFor).getTime()
-      return (
-        scheduledForTimestamp >= filters.dateRange?.start &&
-        scheduledForTimestamp <= filters.dateRange?.end
-      )
+      return scheduledForTimestamp >= dateRange.start && scheduledForTimestamp <= dateRange.end
     })
   }
 

--- a/frontend/src/utils/apiTransformers.ts
+++ b/frontend/src/utils/apiTransformers.ts
@@ -107,7 +107,7 @@ export function transformApiProspect(apiProspect: ApiProspect): Prospect {
     sourceArticle: {
       title: apiProspect.sourceArticle.title || "",
       uri: apiProspect.sourceArticle.uri || "",
-      publishedAt: apiProspect.sourceArticle.publishedAt,
+      publishedAt: apiProspect.sourceArticle.publishedAt ?? undefined,
     },
     signalStrength: apiProspect.signalStrength,
     detectedAt: apiProspect.detectedAt,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -53,6 +53,16 @@ pre-push:
         - "**/*.tsx"
         - "**/*.json"
       run: bun type-check
+    frontend-typecheck:
+      root: "frontend/"
+      glob:
+        - "*.ts"
+        - "*.tsx"
+        - "*.json"
+        - "**/*.ts"
+        - "**/*.tsx"
+        - "**/*.json"
+      run: npx tsc --noEmit
     frontend-build:
       root: "frontend/"
       glob:


### PR DESCRIPTION
## Summary

- Fixes the 4 remaining `frontend && npx tsc --noEmit` errors so the frontend type-checks cleanly on `main`.
- Wires `tsc --noEmit` into both the lefthook `pre-push` hook (before the slower Vite build) and the GitHub Actions frontend job (between Biome checks and Build) so future regressions are blocked at PR time.

## Type errors fixed

- **`services/autoFollowUpService.ts`** (TS18048 ×2) — destructure `const { dateRange } = filters` into a local binding so TypeScript narrows it inside the filter closure (the optional-chain pattern doesn't narrow through callbacks).
- **`src/utils/apiTransformers.ts`** (TS2322) — convert API `sourceArticle.publishedAt` from `string | null` → `string | undefined` at the transformer boundary (`?? undefined`), matching the pattern used elsewhere in the file.
- **`index.tsx`** (TS7016) — add `@types/react-dom@^19` (and bump `@types/react` to `^19` to track) to provide declarations for `react-dom/client` under React 19.
- **`contexts/AuthContext.tsx`** (TS2352 ×2) — replace `as unknown as User` / `response.data.user as User` casts with a real `isUser(value): value is User` type guard plus an `extractUser` helper that handles both shapes (`getCurrentUser` returns the user directly; `register`/`login` wrap it under a `user` key). Invalid responses now return a typed error instead of silently coercing.

## Gate additions

- **`lefthook.yml`** — new `frontend-typecheck` command in `pre-push` (`npx tsc --noEmit`, scoped via `glob: *.ts, *.tsx, *.json`) ordered before `frontend-build` so types fail fast.
- **`.github/workflows/ci.yml`** — new `Type-check (tsc)` step in the frontend job, placed after `Lint (Biome)` + `Format check (Biome)` and before `Build`.

## Verification

Run locally from the worktree:

- `cd frontend && npx tsc --noEmit` → no errors
- `cd frontend && npm run lint:check` → no fixes applied
- `cd frontend && npm run format:check` → no fixes applied
- `cd frontend && npm run build` → built in ~3s
- `cd elysia-server && bun lint:check && bun run format:check && bun type-check` → all clean

## Test plan

- [ ] CI: backend job green
- [ ] CI: frontend job green (new `Type-check (tsc)` step appears between Format check and Build)
- [ ] Manual sanity: `npm run dev` boots, login/register flow still works (the new `extractUser` guard accepts the current `/auth/me` and `/auth/login` payloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the remaining frontend TypeScript errors and gate `tsc --noEmit` in pre-push and CI to block regressions. Improves `AuthContext` type safety and aligns API transforms with expected shapes.

- **Bug Fixes**
  - `services/autoFollowUpService.ts`: Destructure `filters.dateRange` so TS narrows inside the filter callback.
  - `src/utils/apiTransformers.ts`: Map `publishedAt` `null` → `undefined` at the transformer boundary.
  - `contexts/AuthContext.tsx`: Replace casts with `isUser` and `extractUser` helpers; return typed errors for invalid auth responses.
  - `frontend/package.json`: Add `@types/react-dom@^19` and bump `@types/react` to support `react-dom/client` on React 19.

- **Refactors**
  - `lefthook.yml`: Add `frontend-typecheck` (runs `npx tsc --noEmit`) before the frontend build in `pre-push`.
  - `.github/workflows/ci.yml`: Add a “Type-check (tsc)” step between format and build in the frontend job.

<sup>Written for commit 6313777f75f68d5d9930a1b50a213f2aa7894671. Summary will update on new commits. <a href="https://cubic.dev/pr/FINGU-GRINDA/rinda-ai-crm/pull/60?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

