### PR TITLE
fix(frontend): replace undefined LoadingFallback on /deals route

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="theme-color" content="#f8fafc" />

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -96,7 +96,7 @@ export const router = createBrowserRouter([
         path: "deals",
         element: (
           <ProtectedRoute>
-            <Suspense fallback={<LoadingFallback />}>
+            <Suspense fallback={<AgenticLoader variant="page" />}>
               <DealsPage />
             </Suspense>
           </ProtectedRoute>


### PR DESCRIPTION
## Summary

Runtime in production crashed with `Uncaught ReferenceError: LoadingFallback is not defined`, blocking access to the app.

## Root cause

- Commit `91f46307` (deal pipeline foundation) introduced a local `LoadingFallback` component and used it as the `Suspense` fallback for the `/deals` route.
- Commit `acd997e` (agentic loader redesign) deleted the `LoadingFallback` definition and migrated every callsite to `<AgenticLoader variant="page" />` — except the `/deals` route, which still referenced the now-undefined name.
- `npx tsc --noEmit` reproduces the error locally (`TS2304: Cannot find name 'LoadingFallback'`), and CI runs the same check, so future regressions of this shape will be gated.

## Fix

Replace the dangling `<LoadingFallback />` with `<AgenticLoader variant="page" />`, matching the convention used by every other route in `src/router.tsx`.

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — clean (Vite production build succeeds)

## Test plan

- [ ] Navigate to `/deals` — page loads through the branded `AgenticLoader` instead of crashing
- [ ] Browser console shows no `ReferenceError`
- [ ] Other routes (`/dashboard`, `/login`, `/auth`) still render their loaders correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01N2VwYBv7CmppNLwz72rzCE)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a runtime crash on the `/deals` route by replacing the undefined `LoadingFallback` with `<AgenticLoader variant="page" />`, matching other routes. Also added the standard `<meta name="mobile-web-app-capable" content="yes" />` to address a Chrome warning while preserving iOS behavior.

<sup>Written for commit b326ce60fd6585af959e760f9c8127b4ff2caf75. Summary will update on new commits. <a href="https://cubic.dev/pr/FINGU-GRINDA/rinda-ai-crm/pull/62?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

